### PR TITLE
Imcc tag

### DIFF
--- a/t/advanced/10multi_basic.t
+++ b/t/advanced/10multi_basic.t
@@ -1,0 +1,20 @@
+#! winxed
+
+// Basic tests for function modifiers with multiple arguments. In this case,
+// :multi.
+
+using extern Test.More plan, is;
+
+function Foo[multi("_", "_")](a, b) { return a + b; }
+
+function Foo[multi("_")](a) { return a; }
+
+function main[main]()
+{
+    plan(2);
+    var foo;
+    ${ get_global foo, "Foo" };
+    is(foo(5), 5, "Can get 1-arity multi");
+    is(foo(4,5), 9, "Can get 2-arity multi");
+}
+

--- a/winxedst1.winxed
+++ b/winxedst1.winxed
@@ -8469,6 +8469,8 @@ class FunctionModifierList : ModifierList
                     if (!argmod.isstringliteral())
                         SyntaxError('Invalid modifier', argmod);
                     e.print(argmod.getPirString());
+                    if (iargmod < nargmods - 1)
+                        e.print(", ");
                 }
                 e.print(')');
             }


### PR DESCRIPTION
I've fixed a bug in parsing modifier lists with multiple string arguments. In master, a comma is not emitted between them, so this:

```
function Foo[multi("a", "b")] (a,b) { ... }
```

Is output as this:

```
.sub 'Foo' :multi("a""b") ...
```

I've also added a test showing how we can use this improvement to add :multi to Winxed code (multi example is ugly, but it works)
