### PR TITLE
Func deref

### DIFF
--- a/t/advanced/10func_deref.t
+++ b/t/advanced/10func_deref.t
@@ -1,0 +1,20 @@
+#! winxed
+
+// Tests for the new prefix:* function dereference operator
+
+using extern Test.More plan, is;
+
+namespace Foo {
+    namespace Bar {
+        function baz() { return "Foo.Bar.baz"; }
+    }
+    function baz() { return "Foo.baz"; }
+}
+
+function main[main]()
+{
+    plan(2);
+    is(*Foo.Bar.baz(), "Foo.Bar.baz", "Can get 1-arity multi");
+    is(*Foo.baz(), "Foo.baz", "Can get 2-arity multi");
+}
+

--- a/winxedst1.winxed
+++ b/winxedst1.winxed
@@ -3304,6 +3304,38 @@ class OpClassExpr : OpExpr
 
 //*********************************************
 
+class OpFuncDerefExpr : OpExpr
+{
+    var funcloc;
+
+    function OpFuncDerefExpr(tk, owner, start)
+    {
+        self.initop(owner, start);
+        var path = parseDotted(tk);
+        if (elements(path) == 0)
+            ExpectedIdentifier(tk.get());
+        self.funcloc = path;
+    }
+    function checkresult() { return REGvar; }
+    function emit(e, result)
+    {
+        var funcloc = self.funcloc;
+        if (result == '')
+            result = self.owner.tempreg(REGvar);
+
+        string name = funcloc[-1];
+        self.annotate(e);
+        string key;
+        if (elements(funcloc) > 1) {
+            funcloc.pop();
+            key = getparrotkey(funcloc);
+        }
+        e.emitget_hll_global(result, name, key);
+    }
+}
+
+//*********************************************
+
 class OpUnaryExpr : OpExpr
 {
     var subexpr;
@@ -6445,6 +6477,8 @@ function parseExpr_0(tk, owner)
         return new OpClassExpr(tk, owner, t);
       case t.isidentifier():
         return new IdentifierExpr(owner, t);
+      case t.isop('*'):
+        return new OpFuncDerefExpr(tk, owner, t);
       default:
         Expected('expression', t);
     }


### PR DESCRIPTION
This adds in a new prefix:\* operator to do inline function lookups. This:

```
using Foo.Bar.baz;
baz();
```

Can now be written like this:

```
*Foo.Bar.baz();
```

Obviously we can change this to a different operator, if you prefer something else.
