### PR TITLE
Show -dev on version for development builds

### DIFF
--- a/winxedst1.winxed
+++ b/winxedst1.winxed
@@ -10801,7 +10801,15 @@ class WinxedHLL
     }
     function version_string()
     {
-        return "Winxed " + string(join(".", self.version()));
+        var version = self.version();
+        string tail;
+
+        if (version[2] < 0) {
+            version[2] = -int(version[2]) - 1;
+            tail = "-dev";
+        }
+
+        return "Winxed " + string(join(".", version)) + tail;
     }
     function __private_compile_tail(winxed, target, output, int debug, int noan)
     {


### PR DESCRIPTION
Version numbers like 1.4.-1 are somewhat unexpected for users.
Instead, we should display versions like 1.4.0-dev.  This patch does
that and allows any negative number to be used as a development
version so 1.4.-2 would be shown as 1.4.1-dev.
